### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/bjackman/limmat/compare/v0.2.0...v0.2.1) - 2024-11-23
+
+### Other
+
+- Add author to Cargo.toml
+- *(dev)* Notes
+
 ## [0.2.0](https://github.com/bjackman/local-ci/compare/v0.1.0...v0.1.1) - 2024-11-23
 
 This is the first "proper" relase. I've added documentation and the initial featureset.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "limmat"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ansi-control-codes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limmat"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "GPL-3.0-only"
 description = "Tool to run continuous tests locally on Git revision ranges."


### PR DESCRIPTION
## 🤖 New release
* `limmat`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/bjackman/limmat/compare/v0.2.0...v0.2.1) - 2024-11-23

### Other

- Add author to Cargo.toml
- *(dev)* Notes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).