### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/bjackman/limmat/compare/v0.2.1...v0.2.2) - 2024-11-25
+
+### Added
+
+- Add favicon
+- Add a proper title to the web UI tab
+- Support finding stderr as well as stdout
+- Implement 'get' command
+- Add default for --config
+
+### Fixed
+
+- Fixup LIMMAT_RESOURCE_ env handling
+- Move database checking into TestJob
+- Move test result reporting into Job
+
+### Other
+
+- Use shared repo in another test
+- Dump config & args to debug log
+- Share repo between runs in should_find_output
+- It works on MacOS
+- *(dev)* Notes on bugs
+- Use Default for default
+- Add some debug logging
+- More tests for 'test' command
+- Remove cache_lookup helper
+- Basic tests for 'test' command
+- Some more logging tweaks
+- Fiddle around with Job API
+- Fix typos
+- Allow running other subcommands with LimmatChildBuilder
+- Create DatabaseEntry API
+- Renames in database API
+- Make Database::cached_result accept TestCase
+- Stop dancing iterator quadrilles
+- Break out helper to run dependency jobs
+- Use async properly in integration tests
+- *(dev)* Notes on features
+- Fixup order of structs/impls
+- I proofread them
+- Notes on platforms & binaries
+- *(dev)* Notes on packaging
+- More installation notes
+- *(dev)* Notes on release-plz experimentation
+
 ## [0.2.1](https://github.com/bjackman/local-ci/compare/v0.1.0...v0.1.1) - 2024-11-23
 
 This is the first "proper" relase. I've added documentation and the initial featureset.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "limmat"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "ansi-control-codes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limmat"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "GPL-3.0-only"
 description = "Tool to run continuous tests locally on Git revision ranges."


### PR DESCRIPTION
## 🤖 New release
* `limmat`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/bjackman/limmat/compare/v0.2.1...v0.2.2) - 2024-11-25

### Added

- Add favicon
- Add a proper title to the web UI tab
- Support finding stderr as well as stdout
- Implement 'get' command
- Add default for --config

### Fixed

- Fixup LIMMAT_RESOURCE_ env handling
- Move database checking into TestJob
- Move test result reporting into Job

### Other

- Use shared repo in another test
- Dump config & args to debug log
- Share repo between runs in should_find_output
- It works on MacOS
- *(dev)* Notes on bugs
- Use Default for default
- Add some debug logging
- More tests for 'test' command
- Remove cache_lookup helper
- Basic tests for 'test' command
- Some more logging tweaks
- Fiddle around with Job API
- Fix typos
- Allow running other subcommands with LimmatChildBuilder
- Create DatabaseEntry API
- Renames in database API
- Make Database::cached_result accept TestCase
- Stop dancing iterator quadrilles
- Break out helper to run dependency jobs
- Use async properly in integration tests
- *(dev)* Notes on features
- Fixup order of structs/impls
- I proofread them
- Notes on platforms & binaries
- *(dev)* Notes on packaging
- More installation notes
- *(dev)* Notes on release-plz experimentation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

Close https://github.com/bjackman/limmat/issues/7