### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/bjackman/limmat/compare/v0.2.2...v0.2.3) - 2024-12-12
+
+### Added
+
+- Make some args global
+- Implement initial database locking
+
+### Fixed
+
+- Retry git worktree creation
+- Implement read locking too
+- Implement proper database entry locking
+- Recover correctly from broken database results
+- Don't panic
+- Note in --help that "get" is experimental
+
+### Other
+
+- Hack to make should_not_race failures easier to read
+- Log config hashes
+- Bring back warning about locking
+- Add comment on garbage flocking
+- Hacks to make race failures easier to debug
+- Add a log for test status changes
+- Clean up database lookup logging
+- Fix clippy
+- cargo fmt
+- Remove unnecessary remark
+- Fix bugs in dag module
+- Add failing test cases for dag::tests
+- Make I an associated type of trait GraphNode
+- Remove warning about race conditions
+- Add test for locking database entries
+- More detailed errors
+- Clean up TestJob notifying etc a bit
+- checkpoint
+- checkpoint
+- Make run_inner return TestOutcome
+- Make TestOutcome be a Result
+- Split up TestStatus and TestOutcome
+- Move output creation into TestJob::run
+- *(dev)* Add warning about locking
+- *(dev)* Notes on config repos
+- *(dev)* Bug notes
+- Fix new Clippy lints
+- *(dev)* Notes on flock
+- Remove timestamp argument from commit funcs
+- Pull out TestJob::set_env
+- Don't print noise when running 0 dep tests
+- *(dev)* Notes
+- Clarify `limmat test` intention
+- I accidentally a word
+
 ## [0.2.2](https://github.com/bjackman/limmat/compare/v0.2.1...v0.2.2) - 2024-11-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "limmat"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ansi-control-codes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limmat"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "GPL-3.0-only"
 description = "Tool to run continuous tests locally on Git revision ranges."

--- a/src/git.rs
+++ b/src/git.rs
@@ -464,17 +464,27 @@ impl TempWorktree {
             temp_dir,
             cleaned_up: false,
         };
-        let mut cmd = origin.git(["worktree", "add"]);
-        let cmd = cmd.arg(zelf.temp_dir.path()).arg("HEAD");
-        select! {
-            _ = ct.cancelled().fuse() => {
-                zelf.cleanup().await;
-                bail!("canceled")
-            },
-            res = cmd.execute().fuse() => {
-                res.context("'git worktree add' failed")?;
-                Ok(zelf)
-            },
+        let mut attempts = 1;
+        loop {
+            let mut cmd = origin.git(["worktree", "add"]);
+            let cmd = cmd.arg(zelf.temp_dir.path()).arg("HEAD");
+            select! {
+                _ = ct.cancelled().fuse() => {
+                    zelf.cleanup().await;
+                    bail!("canceled")
+                },
+                res = cmd.execute().fuse() => {
+                    match res {
+                        Ok(_) => return Ok(zelf),
+                        Err(e) => {
+                            if attempts >= 5 {
+                                bail!("git worktree add failed: {}", e);
+                            }
+                            attempts += 1;
+                        },
+                    }
+                },
+            }
         }
     }
 


### PR DESCRIPTION
## 🤖 New release
* `limmat`: 0.2.2 -> 0.2.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/bjackman/limmat/compare/v0.2.2...v0.2.3) - 2024-12-12

### Added

- Make some args global
- Implement initial database locking

### Fixed

- Retry git worktree creation
- Implement read locking too
- Implement proper database entry locking
- Recover correctly from broken database results
- Don't panic
- Note in --help that "get" is experimental

### Other

- Hack to make should_not_race failures easier to read
- Log config hashes
- Bring back warning about locking
- Add comment on garbage flocking
- Hacks to make race failures easier to debug
- Add a log for test status changes
- Clean up database lookup logging
- Fix clippy
- cargo fmt
- Remove unnecessary remark
- Fix bugs in dag module
- Add failing test cases for dag::tests
- Make I an associated type of trait GraphNode
- Remove warning about race conditions
- Add test for locking database entries
- More detailed errors
- Clean up TestJob notifying etc a bit
- checkpoint
- checkpoint
- Make run_inner return TestOutcome
- Make TestOutcome be a Result
- Split up TestStatus and TestOutcome
- Move output creation into TestJob::run
- *(dev)* Add warning about locking
- *(dev)* Notes on config repos
- *(dev)* Bug notes
- Fix new Clippy lints
- *(dev)* Notes on flock
- Remove timestamp argument from commit funcs
- Pull out TestJob::set_env
- Don't print noise when running 0 dep tests
- *(dev)* Notes
- Clarify `limmat test` intention
- I accidentally a word
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).