### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,110 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/bjackman/limmat/compare/v0.2.2...v0.2.3) - 2024-12-24
+
+### Added
+
+- Log to file on disk (WIP)
+- Add --git-binary arg
+- Slightly better visibility for startup/shutdown
+- Return exit code 50 for nonexistent results
+- Implement LIMMAT_ARTIFACTS_<dep>
+- Add "artifacts" command
+- Add $LIMMAT_ARTIFACTS
+- Make some args global
+- Implement initial database locking
+
+### Fixed
+
+- Fix switching to/from alternate screen
+- Better message on fatal error
+- Use correct test name in watch
+- Use correct test name
+- Try a cryptographic hash for configuration
+- Retry git worktree creation
+- Implement read locking too
+- Implement proper database entry locking
+- Recover correctly from broken database results
+- Don't panic
+- Note in --help that "get" is experimental
+
+### Other
+
+- Drop debug logs
+- Finish documenting artifacts
+- Spellcheck README
+- Reapply "doc: Partially document artifacts"
+- Create repos in LimmatChildBuilder::new
+- Use fixed git binary in integration tests
+- Revert "test: Embiggen some test timeouts"
+- Rename StatusTracker->StatusViewer
+- Make config hashes strings
+- cargo add hex
+- Embiggen some test timeouts
+- Use fancy exit status to detect readiness
+- Fixup awaiting readiness for clean shutdown
+- Remove some unnecessary config variables
+- Enable incremental mode?
+- Make config an argument of builder constructor
+- Make LimmatChildBuilders reusable
+- Remove a debug log
+- Make test_job_env multi-commit
+- Smoke test for artifact env vars
+- Revert "doc: Partially document artifacts"
+- Partially document artifacts
+- Smoke tests for dependency artifacts
+- Make TestOutcome contain a DB entry
+- Remove TestJobOutput trait
+- Make DatabaseOutput::set_result return the created entry
+- Create DatabaseOutput::ephemeral
+- Make DatabaseOutput directly return Stdio
+- Remove unnecessary pub
+- Make DatabaseOutput::set_result consume self
+- Comment on DB locking
+- Revert "cleanup: Ensure no double-opened databases"
+- Ensure no double-opened databases
+- Integration test for test subcommand
+- cargo add sha3
+- Add transitive trust for cargo-vet
+- Add some more cargo-vet imports
+- Import google's audit and prune exceptions
+- Add cargo-vet config
+- Hack to make should_not_race failures easier to read
+- Log config hashes
+- Bring back warning about locking
+- Add comment on garbage flocking
+- Hacks to make race failures easier to debug
+- Add a log for test status changes
+- Clean up database lookup logging
+- Fix clippy
+- cargo fmt
+- Remove unnecessary remark
+- Fix bugs in dag module
+- Add failing test cases for dag::tests
+- Make I an associated type of trait GraphNode
+- Remove warning about race conditions
+- Add test for locking database entries
+- More detailed errors
+- Clean up TestJob notifying etc a bit
+- checkpoint
+- checkpoint
+- Make run_inner return TestOutcome
+- Make TestOutcome be a Result
+- Split up TestStatus and TestOutcome
+- Move output creation into TestJob::run
+- *(dev)* Add warning about locking
+- *(dev)* Notes on config repos
+- *(dev)* Bug notes
+- Fix new Clippy lints
+- *(dev)* Notes on flock
+- Remove timestamp argument from commit funcs
+- Pull out TestJob::set_env
+- Don't print noise when running 0 dep tests
+- *(dev)* Notes
+- Clarify `limmat test` intention
+- I accidentally a word
+
 ## [0.2.2](https://github.com/bjackman/limmat/compare/v0.2.1...v0.2.2) - 2024-11-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "limmat"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ansi-control-codes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi-control-codes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +253,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +271,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
+name = "cc"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +290,18 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "chrono"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "clap"
@@ -336,6 +378,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -474,7 +522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
  "log",
- "regex",
 ]
 
 [[package]]
@@ -486,7 +533,6 @@ dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "humantime",
  "log",
 ]
 
@@ -522,6 +568,19 @@ dependencies = [
  "libc",
  "libredox",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "flexi_logger"
+version = "0.29.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a5a6882b2e137c4f2664562995865084eb5a00611fba30c582ef10354c4ad8"
+dependencies = [
+ "chrono",
+ "log",
+ "nu-ansi-term 0.50.1",
+ "regex",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -769,12 +828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +860,29 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -865,6 +941,16 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "js-sys"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "keccak"
@@ -931,7 +1017,7 @@ dependencies = [
  "colored",
  "crossterm",
  "directories",
- "env_logger",
+ "flexi_logger",
  "futures",
  "futures-core",
  "glob",
@@ -1097,6 +1183,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,7 +1352,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -1479,6 +1574,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,7 +1752,16 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.68",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+dependencies = [
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -1659,6 +1769,17 @@ name = "thiserror-impl"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1864,7 +1985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
- "nu-ansi-term",
+ "nu-ansi-term 0.46.0",
  "once_cell",
  "regex",
  "sharded-slab",
@@ -1888,7 +2009,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.68",
  "utf-8",
 ]
 
@@ -1977,6 +2098,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,6 +2181,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limmat"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "GPL-3.0-only"
 description = "Tool to run continuous tests locally on Git revision ranges."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ futures = "0.3.30"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 async-stream = "0.3"
-env_logger = "0.11"
 log = "0.4"
 async-condvar-fair = { version = "1.0", features = [ "parking_lot_0_12" ] }
 # https://docs.rs/async-condvar-fair/latest/async_condvar_fair/#mutex-guard-sending-between-threads
@@ -48,6 +47,7 @@ crossterm = {version = "0.28.1", features = ["event-stream"] }
 schemars = "0.8.21"
 sha3 = "0.10.8"
 hex = "0.4.3"
+flexi_logger = "0.29.8"
 
 [dev-dependencies]
 test-case = "3.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use clap::{arg, Parser as _, Subcommand, ValueEnum};
 use config::{Config, ParsedConfig};
 use dag::{Dag, GraphNode as _};
 use database::{Database, DatabaseEntry, DatabaseOutput, LookupResult};
+use flexi_logger::{detailed_format, Cleanup, Criterion, FileSpec, Logger, Naming};
 use futures::future::join_all;
 use futures::StreamExt;
 use git::{Commit, PersistentWorktree, TempWorktree};
@@ -20,7 +21,7 @@ use std::io::{stdout, Stdout};
 use std::path::{absolute, PathBuf};
 use std::pin::pin;
 use std::process::{ExitCode, Stdio};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::{env, fmt, fs, str};
 use tempfile::TempDir;
 use test::{base_job_env, Manager, TestCase, TestCaseId, TestJob, TestJobBuilder, TestName};
@@ -93,13 +94,12 @@ struct WatchArgs {
     base: String,
 }
 
+static PROJECT_DIRS: LazyLock<directories::ProjectDirs> = LazyLock::new(|| {
+    directories::ProjectDirs::from("", "", "limmat").expect("couldn't find user data dir")
+});
+
 fn default_result_db() -> DisplayablePathBuf {
-    DisplayablePathBuf(
-        directories::ProjectDirs::from("", "", "limmat")
-            .expect("couldn't find user data dir")
-            .data_local_dir()
-            .to_owned(),
-    )
+    DisplayablePathBuf(PROJECT_DIRS.data_local_dir().to_owned())
 }
 
 fn default_hostname() -> String {
@@ -636,11 +636,33 @@ async fn artifacts(
     Ok(ExitCode::SUCCESS)
 }
 
+const MEGABYTE: u64 = 1024 * 1024;
+
 // Hack so we can use anyhow::Result infrastructure for convenient coding but
 // also control the exit code directly in some cases: return a result - if it's
 // an error we just use the default error exit code.
 async fn do_main() -> anyhow::Result<ExitCode> {
-    env_logger::init();
+    let mut logger = Logger::try_with_env_or_str("debug")?.format(detailed_format);
+    logger = match env::var_os("LIMMAT_LOGFILE") {
+        Some(path) => logger.log_to_file(
+            FileSpec::try_from(&path)
+                .with_context(|| format!("configuring logging to {:?}", path))?,
+        ),
+        None => {
+            let log_dir = PROJECT_DIRS
+                .state_dir()
+                .unwrap_or(PROJECT_DIRS.data_local_dir());
+            logger
+                .log_to_file(FileSpec::default().directory(log_dir))
+                .create_symlink(log_dir.join("latest.log"))
+                .rotate(
+                    Criterion::Size(64 * MEGABYTE),
+                    Naming::TimestampsDirect,
+                    Cleanup::KeepLogFiles(10),
+                )
+        }
+    };
+    logger.start()?;
 
     // Set up shutdown first, to ensure we correctly handle early signals.
     // It seems extremely difficult to use Tokio's ctrl_c API for this correctly


### PR DESCRIPTION
## 🤖 New release
* `limmat`: 0.2.2 -> 0.2.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/bjackman/limmat/compare/v0.2.2...v0.2.3) - 2024-12-24

### Added

- Log to file on disk (WIP)
- Add --git-binary arg
- Slightly better visibility for startup/shutdown
- Return exit code 50 for nonexistent results
- Implement LIMMAT_ARTIFACTS_<dep>
- Add "artifacts" command
- Add $LIMMAT_ARTIFACTS
- Make some args global
- Implement initial database locking

### Fixed

- Fix switching to/from alternate screen
- Better message on fatal error
- Use correct test name in watch
- Use correct test name
- Try a cryptographic hash for configuration
- Retry git worktree creation
- Implement read locking too
- Implement proper database entry locking
- Recover correctly from broken database results
- Don't panic
- Note in --help that "get" is experimental

### Other

- Drop debug logs
- Finish documenting artifacts
- Spellcheck README
- Reapply "doc: Partially document artifacts"
- Create repos in LimmatChildBuilder::new
- Use fixed git binary in integration tests
- Revert "test: Embiggen some test timeouts"
- Rename StatusTracker->StatusViewer
- Make config hashes strings
- cargo add hex
- Embiggen some test timeouts
- Use fancy exit status to detect readiness
- Fixup awaiting readiness for clean shutdown
- Remove some unnecessary config variables
- Enable incremental mode?
- Make config an argument of builder constructor
- Make LimmatChildBuilders reusable
- Remove a debug log
- Make test_job_env multi-commit
- Smoke test for artifact env vars
- Revert "doc: Partially document artifacts"
- Partially document artifacts
- Smoke tests for dependency artifacts
- Make TestOutcome contain a DB entry
- Remove TestJobOutput trait
- Make DatabaseOutput::set_result return the created entry
- Create DatabaseOutput::ephemeral
- Make DatabaseOutput directly return Stdio
- Remove unnecessary pub
- Make DatabaseOutput::set_result consume self
- Comment on DB locking
- Revert "cleanup: Ensure no double-opened databases"
- Ensure no double-opened databases
- Integration test for test subcommand
- cargo add sha3
- Add transitive trust for cargo-vet
- Add some more cargo-vet imports
- Import google's audit and prune exceptions
- Add cargo-vet config
- Hack to make should_not_race failures easier to read
- Log config hashes
- Bring back warning about locking
- Add comment on garbage flocking
- Hacks to make race failures easier to debug
- Add a log for test status changes
- Clean up database lookup logging
- Fix clippy
- cargo fmt
- Remove unnecessary remark
- Fix bugs in dag module
- Add failing test cases for dag::tests
- Make I an associated type of trait GraphNode
- Remove warning about race conditions
- Add test for locking database entries
- More detailed errors
- Clean up TestJob notifying etc a bit
- checkpoint
- checkpoint
- Make run_inner return TestOutcome
- Make TestOutcome be a Result
- Split up TestStatus and TestOutcome
- Move output creation into TestJob::run
- *(dev)* Add warning about locking
- *(dev)* Notes on config repos
- *(dev)* Bug notes
- Fix new Clippy lints
- *(dev)* Notes on flock
- Remove timestamp argument from commit funcs
- Pull out TestJob::set_env
- Don't print noise when running 0 dep tests
- *(dev)* Notes
- Clarify `limmat test` intention
- I accidentally a word
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).