### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,123 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/bjackman/limmat/compare/v0.2.2...v0.2.3) - 2025-01-08
+
+### Added
+
+- Add error_exit_codes
+- Log to file on disk
+- Add --git-binary arg
+- Slightly better visibility for startup/shutdown
+- Return exit code 50 for nonexistent results
+- Implement LIMMAT_ARTIFACTS_<dep>
+- Add "artifacts" command
+- Add $LIMMAT_ARTIFACTS
+- Make some args global
+- Implement initial database locking
+
+### Fixed
+
+- Fix switching to/from alternate screen
+- Better message on fatal error
+- Use correct test name in watch
+- Use correct test name
+- Try a cryptographic hash for configuration
+- Retry git worktree creation
+- Implement read locking too
+- Implement proper database entry locking
+- Recover correctly from broken database results
+- Don't panic
+- Note in --help that "get" is experimental
+
+### Other
+
+- Add anchor link
+- Document LIMMAT_ARTIFACTS_x
+- Words
+- Add builder for tests
+- Support expecting arbitrary exit codes
+- Dump stderr/stdout on error too
+- *(dev)* Give myself a TODO list
+- *(dev)* Tick off some completed tasks
+- Avoid N git commands for building UI buffer
+- Return raw bytes from Worktree::log
+- Add style argument to Worktree::log
+- Shrink OutputBuffer::new
+- Drop debug logs
+- Finish documenting artifacts
+- Spellcheck README
+- Reapply "doc: Partially document artifacts"
+- Create repos in LimmatChildBuilder::new
+- Use fixed git binary in integration tests
+- Revert "test: Embiggen some test timeouts"
+- Rename StatusTracker->StatusViewer
+- Make config hashes strings
+- cargo add hex
+- Embiggen some test timeouts
+- Use fancy exit status to detect readiness
+- Fixup awaiting readiness for clean shutdown
+- Remove some unnecessary config variables
+- Enable incremental mode?
+- Make config an argument of builder constructor
+- Make LimmatChildBuilders reusable
+- Remove a debug log
+- Make test_job_env multi-commit
+- Smoke test for artifact env vars
+- Revert "doc: Partially document artifacts"
+- Partially document artifacts
+- Smoke tests for dependency artifacts
+- Make TestOutcome contain a DB entry
+- Remove TestJobOutput trait
+- Make DatabaseOutput::set_result return the created entry
+- Create DatabaseOutput::ephemeral
+- Make DatabaseOutput directly return Stdio
+- Remove unnecessary pub
+- Make DatabaseOutput::set_result consume self
+- Comment on DB locking
+- Revert "cleanup: Ensure no double-opened databases"
+- Ensure no double-opened databases
+- Integration test for test subcommand
+- cargo add sha3
+- Add transitive trust for cargo-vet
+- Add some more cargo-vet imports
+- Import google's audit and prune exceptions
+- Add cargo-vet config
+- Hack to make should_not_race failures easier to read
+- Log config hashes
+- Bring back warning about locking
+- Add comment on garbage flocking
+- Hacks to make race failures easier to debug
+- Add a log for test status changes
+- Clean up database lookup logging
+- Fix clippy
+- cargo fmt
+- Remove unnecessary remark
+- Fix bugs in dag module
+- Add failing test cases for dag::tests
+- Make I an associated type of trait GraphNode
+- Remove warning about race conditions
+- Add test for locking database entries
+- More detailed errors
+- Clean up TestJob notifying etc a bit
+- checkpoint
+- checkpoint
+- Make run_inner return TestOutcome
+- Make TestOutcome be a Result
+- Split up TestStatus and TestOutcome
+- Move output creation into TestJob::run
+- *(dev)* Add warning about locking
+- *(dev)* Notes on config repos
+- *(dev)* Bug notes
+- Fix new Clippy lints
+- *(dev)* Notes on flock
+- Remove timestamp argument from commit funcs
+- Pull out TestJob::set_env
+- Don't print noise when running 0 dep tests
+- *(dev)* Notes
+- Clarify `limmat test` intention
+- I accidentally a word
+
 ## [0.2.2](https://github.com/bjackman/limmat/compare/v0.2.1...v0.2.2) - 2024-11-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "limmat"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ansi-control-codes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limmat"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "GPL-3.0-only"
 description = "Tool to run continuous tests locally on Git revision ranges."


### PR DESCRIPTION
## 🤖 New release
* `limmat`: 0.2.2 -> 0.2.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/bjackman/limmat/compare/v0.2.2...v0.2.3) - 2025-01-08

### Added

- Add error_exit_codes
- Log to file on disk
- Add --git-binary arg
- Slightly better visibility for startup/shutdown
- Return exit code 50 for nonexistent results
- Implement LIMMAT_ARTIFACTS_<dep>
- Add "artifacts" command
- Add $LIMMAT_ARTIFACTS
- Make some args global
- Implement initial database locking

### Fixed

- Fix switching to/from alternate screen
- Better message on fatal error
- Use correct test name in watch
- Use correct test name
- Try a cryptographic hash for configuration
- Retry git worktree creation
- Implement read locking too
- Implement proper database entry locking
- Recover correctly from broken database results
- Don't panic
- Note in --help that "get" is experimental

### Other

- Add anchor link
- Document LIMMAT_ARTIFACTS_x
- Words
- Add builder for tests
- Support expecting arbitrary exit codes
- Dump stderr/stdout on error too
- *(dev)* Give myself a TODO list
- *(dev)* Tick off some completed tasks
- Avoid N git commands for building UI buffer
- Return raw bytes from Worktree::log
- Add style argument to Worktree::log
- Shrink OutputBuffer::new
- Drop debug logs
- Finish documenting artifacts
- Spellcheck README
- Reapply "doc: Partially document artifacts"
- Create repos in LimmatChildBuilder::new
- Use fixed git binary in integration tests
- Revert "test: Embiggen some test timeouts"
- Rename StatusTracker->StatusViewer
- Make config hashes strings
- cargo add hex
- Embiggen some test timeouts
- Use fancy exit status to detect readiness
- Fixup awaiting readiness for clean shutdown
- Remove some unnecessary config variables
- Enable incremental mode?
- Make config an argument of builder constructor
- Make LimmatChildBuilders reusable
- Remove a debug log
- Make test_job_env multi-commit
- Smoke test for artifact env vars
- Revert "doc: Partially document artifacts"
- Partially document artifacts
- Smoke tests for dependency artifacts
- Make TestOutcome contain a DB entry
- Remove TestJobOutput trait
- Make DatabaseOutput::set_result return the created entry
- Create DatabaseOutput::ephemeral
- Make DatabaseOutput directly return Stdio
- Remove unnecessary pub
- Make DatabaseOutput::set_result consume self
- Comment on DB locking
- Revert "cleanup: Ensure no double-opened databases"
- Ensure no double-opened databases
- Integration test for test subcommand
- cargo add sha3
- Add transitive trust for cargo-vet
- Add some more cargo-vet imports
- Import google's audit and prune exceptions
- Add cargo-vet config
- Hack to make should_not_race failures easier to read
- Log config hashes
- Bring back warning about locking
- Add comment on garbage flocking
- Hacks to make race failures easier to debug
- Add a log for test status changes
- Clean up database lookup logging
- Fix clippy
- cargo fmt
- Remove unnecessary remark
- Fix bugs in dag module
- Add failing test cases for dag::tests
- Make I an associated type of trait GraphNode
- Remove warning about race conditions
- Add test for locking database entries
- More detailed errors
- Clean up TestJob notifying etc a bit
- checkpoint
- checkpoint
- Make run_inner return TestOutcome
- Make TestOutcome be a Result
- Split up TestStatus and TestOutcome
- Move output creation into TestJob::run
- *(dev)* Add warning about locking
- *(dev)* Notes on config repos
- *(dev)* Bug notes
- Fix new Clippy lints
- *(dev)* Notes on flock
- Remove timestamp argument from commit funcs
- Pull out TestJob::set_env
- Don't print noise when running 0 dep tests
- *(dev)* Notes
- Clarify `limmat test` intention
- I accidentally a word
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).