### PR TITLE
chore: release v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/bjackman/limmat/compare/v0.2.4...v0.2.5) - 2025-01-26
+
+### Fixed
+
+- Make shutdown a bit more responsive
+- Don't send database references over the global notif channel
+- Bias event-loop towards user action
+- Discard revisions if more than 1024
+- Fix integer underflow
+- Fix terminal flickering with dumb hack
+- Don't panic on dropped notifications
+- Throttle the number of concurrent test jobs
+- Throttle the number of git commands run in parallel
+
+### Other
+
+- Revert "fix: Don't hold database locks from UI code"
+- Fixup failure message
+- Comment on semaphore
+- More verbose logging for Git output mysteries
+- Fix GitHub release link
+- Update stale comment
+- Make Worktree::git a private method
+- Turn Worktree::git into an async method
+- Remove unused impl params
+
 ## [0.2.4](https://github.com/bjackman/limmat/compare/v0.2.3...v0.2.4) - 2025-01-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "limmat"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "ansi-control-codes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limmat"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "GPL-3.0-only"
 description = "Tool to run continuous tests locally on Git revision ranges."


### PR DESCRIPTION
## 🤖 New release
* `limmat`: 0.2.4 -> 0.2.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.5](https://github.com/bjackman/limmat/compare/v0.2.4...v0.2.5) - 2025-01-26

### Fixed

- Make shutdown a bit more responsive
- Don't send database references over the global notif channel
- Bias event-loop towards user action
- Discard revisions if more than 1024
- Fix integer underflow
- Fix terminal flickering with dumb hack
- Don't panic on dropped notifications
- Throttle the number of concurrent test jobs
- Throttle the number of git commands run in parallel

### Other

- Revert "fix: Don't hold database locks from UI code"
- Fixup failure message
- Comment on semaphore
- More verbose logging for Git output mysteries
- Fix GitHub release link
- Update stale comment
- Make Worktree::git a private method
- Turn Worktree::git into an async method
- Remove unused impl params
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).