### PR TITLE
chore: release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/bjackman/limmat/compare/v0.2.5...v0.2.6) - 2025-07-13
+
+### Added
+
+- Add --skip-test arg
+
+### Fixed
+
+- Don't ignore git_binary setting
+
+### Other
+
+- Add Initial flake
+- Add tip on setting --worktree-dir
+- Fix README typo
+- Add limmat-kernel link
+
 ## [0.2.5](https://github.com/bjackman/limmat/compare/v0.2.4...v0.2.5) - 2025-01-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "limmat"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "ansi-control-codes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limmat"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 license = "GPL-3.0-only"
 description = "Tool to run continuous tests locally on Git revision ranges."


### PR DESCRIPTION



## 🤖 New release

* `limmat`: 0.2.5 -> 0.2.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.6](https://github.com/bjackman/limmat/compare/v0.2.5...v0.2.6) - 2025-07-13

### Added

- Add --skip-test arg

### Fixed

- Don't ignore git_binary setting

### Other

- Add Initial flake
- Add tip on setting --worktree-dir
- Fix README typo
- Add limmat-kernel link
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).