### PR TITLE
feat!: Add separate_outputs field

### DIFF
--- a/limmat.schema.json
+++ b/limmat.schema.json
@@ -145,6 +145,11 @@
             "$ref": "#/definitions/Resource"
           }
         },
+        "separate_outputs": {
+          "description": "When false (default), stdout and stderr are merged into output.txt. When true, they are kept separate as stdout.txt and stderr.txt.",
+          "default": false,
+          "type": "boolean"
+        },
         "shutdown_grace_period_s": {
           "description": "When a job is no longer needed it's SIGTERMed. If it doesn't respond (by dying) after this duration it will then be SIGKILLed. This also affects the overall shutdown of limmat so do not set this to longer than you are willing to wait when you terminate this program.",
           "default": 60,

--- a/src/config.rs
+++ b/src/config.rs
@@ -104,10 +104,18 @@ pub struct Test {
     /// use this to report environmental failures such as dependencies missing
     /// fom the host system. 0 is not allowed.
     error_exit_codes: Vec<ExitCode>,
+    #[serde(default = "default_separate_outputs")]
+    /// When false (default), stdout and stderr are merged into output.txt.
+    /// When true, they are kept separate as stdout.txt and stderr.txt.
+    separate_outputs: bool,
 }
 
 fn default_requires_worktree() -> bool {
     true
+}
+
+fn default_separate_outputs() -> bool {
+    false
 }
 
 // This implementation is only valid for Tests among those registered for a single Manager.
@@ -178,6 +186,7 @@ impl Test {
             config_hash,
             depends_on: self.depends_on.iter().map(TestName::new).collect(),
             error_exit_codes,
+            separate_outputs: self.separate_outputs,
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -569,7 +569,13 @@ async fn test(
         "Test artifacts will be stored under {}",
         output_dir.display()
     );
-    let output = DatabaseOutput::ephemeral(output_dir, Stdio::inherit(), Stdio::inherit()).await?;
+    let output = DatabaseOutput::ephemeral(
+        output_dir,
+        Stdio::inherit(),
+        Stdio::inherit(),
+        test.separate_outputs,
+    )
+    .await?;
     let db_entry = job
         .run_with(env.repo.path(), &resources, output, dep_db_entries)
         .await?;

--- a/src/test.rs
+++ b/src/test.rs
@@ -114,6 +114,7 @@ pub struct Test {
     // do not exist.
     pub depends_on: Vec<TestName>,
     pub error_exit_codes: HashSet<ExitCode>,
+    pub separate_outputs: bool,
 }
 
 impl Test {
@@ -1078,6 +1079,7 @@ pub mod test_utils {
                 depends_on: self.depends_on,
                 config_hash: "fake_config_hash".into(),
                 error_exit_codes: HashSet::new(),
+                separate_outputs: false,
             }
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -422,9 +422,14 @@ impl OutputBuffer {
             _ => Span::new(status.to_string()),
         }
         .with_url(format!(
-            "{}/{}/stdout.txt",
+            "{}/{}/{}",
             result_url_base,
-            Database::result_relpath(test_case).to_string_lossy()
+            Database::result_relpath(test_case).to_string_lossy(),
+            if test_case.test.separate_outputs {
+                "stdout.txt"
+            } else {
+                "output.txt"
+            }
         ));
         vec![
             Span::new(test_case.test.name.to_string()).with_class(Class::TestName),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -632,6 +632,7 @@ async fn should_find_output(want_stdout: &str, want_stderr: &str) {
             echo bungle bingle >&2
             touch $LIMMAT_ARTIFACTS/my_artifact
             """
+            separate_outputs = true
 
             shutdown_grace_period_s = 1
         "##,
@@ -849,6 +850,7 @@ static DEP_CONFIG: &str = r##"
     name = "main"
     depends_on = ["dep", "dep2"]
     command = "cat $LIMMAT_ARTIFACTS_dep/ozy $LIMMAT_ARTIFACTS_dep2/trunkless"
+    separate_outputs = true
 "##;
 
 #[googletest::test]


### PR DESCRIPTION
I pretty much always end up writing "exec 2>&1" at the top of all my configs. Let's just make that behaviour the default.

VIBE CODED.

Fixes https://github.com/bjackman/limmat/issues/33